### PR TITLE
Fixed bug markers disappearing near 0°

### DIFF
--- a/app/src/main/java/com/github/bgabriel998/softwaredevproject/camera/CameraUiView.java
+++ b/app/src/main/java/com/github/bgabriel998/softwaredevproject/camera/CameraUiView.java
@@ -342,7 +342,7 @@ public class CameraUiView extends View {
     private void drawPOIs(int actualDegree){
         //Go through all POIPoints
         for(POIPoint poiPoint : POIPoints){
-            if((int)poiPoint.getHorizontalBearing() == actualDegree){
+            if((int)poiPoint.getHorizontalBearing() == (actualDegree + 360) % 360){
                 drawMountainMarker(poiPoint, false, actualDegree);
             }
         }
@@ -356,7 +356,7 @@ public class CameraUiView extends View {
     private void drawLabeledPOIs(int actualDegree){
         //Go through all POIPoints
         labeledPOIPoints.entrySet().stream()
-                .filter(p -> (int)p.getKey().getHorizontalBearing() == actualDegree)
+                .filter(p -> (int)p.getKey().getHorizontalBearing() == (actualDegree + 360) % 360)
                         .forEach(p -> drawMountainMarker(p.getKey(), p.getValue(), actualDegree));
     }
 


### PR DESCRIPTION
Fixed bug #153 
Mountain markers west of north (below 360) or now displayed when looking east of north (above 0°). Same goes other way around.
